### PR TITLE
Use symlinked version agnostic path

### DIFF
--- a/module.modulemap
+++ b/module.modulemap
@@ -1,4 +1,4 @@
 module ASL [system] {
-    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/usr/include/asl.h"
+    header "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/asl.h"
     export *
 }


### PR DESCRIPTION
required for macOS 10.12 Sierra
